### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/core/security/code-scanning/1](https://github.com/android-sms-gateway/core/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the jobs in the workflow. Based on the workflow's tasks:
- The `golangci` job performs linting, which requires only `contents: read`.
- The `test` job performs testing and uploads coverage reports, which also requires only `contents: read`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to each job individually. In this case, adding it at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions for improved repository access management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->